### PR TITLE
Update components.yaml to fix wrong answer and wrong link documentation

### DIFF
--- a/data/symfony_architecture/components.yaml
+++ b/data/symfony_architecture/components.yaml
@@ -237,13 +237,13 @@ questions:
     question: 'Which variables can be used in the ExpressionLanguage expression when using the condition option on a Route?'
     answers:
       - { value: this, correct: false }
-      - { value: object, correct: true }
+      - { value: params, correct: true }
       - { value: container, correct: false }
       - { value: context, correct: true }
       - { value: service, correct: false }
       - { value: user, correct: false }
       - { value: request, correct: true }
-    help: 'https://symfony.com/doc/7.2/routing.html'
+    help: 'https://symfony.com/doc/7.0/routing.html'
   -
     uuid: 1eed5768-e3b6-667a-8f78-21c4c4321b85
     question: 'What is the main purpose of the eraseCredentials() method from the UserInterface?'

--- a/data/symfony_architecture/components.yaml
+++ b/data/symfony_architecture/components.yaml
@@ -243,7 +243,7 @@ questions:
       - { value: service, correct: false }
       - { value: user, correct: false }
       - { value: request, correct: true }
-    help: 'https://symfony.com/doc/7.0/routing.html'
+    help: 'https://symfony.com/doc/7.2/routing.html'
   -
     uuid: 1eed5768-e3b6-667a-8f78-21c4c4321b85
     question: 'What is the main purpose of the eraseCredentials() method from the UserInterface?'


### PR DESCRIPTION
The object variables doesn't exist and can't be used in the ExpressionLanguage for matching expressions. It should be params variable because the variables exists are context, params and request and the existing methods are env() and service()

Besides, the Symfony 7 Certification exam only includes questions about Symfony 7.0 and not about Symfony 7.1, 7.2, 7.3 and 7.4 versions.