### PR TITLE
Update framework_interoperability_and_ps_rs.yaml to fix wrong answer

### DIFF
--- a/data/symfony_architecture/framework_interoperability_and_ps_rs.yaml
+++ b/data/symfony_architecture/framework_interoperability_and_ps_rs.yaml
@@ -362,8 +362,8 @@ questions:
     question: 'What is the method to create a MicroKernel?'
     answers:
       - { value: 'Create an AppKernel and use the Symfony\Component\HttpKernel\MicroKernelTrait trait.', correct: false }
-      - { value: 'Create an AppKernel and use the Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait trait.', correct: false }
-      - { value: 'Create an AppKernel and extends the Symfony\Bundle\FrameworkBundle\Kernel\MicroKernel class.', correct: true }
+      - { value: 'Create an AppKernel and use the Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait trait.', correct: true }
+      - { value: 'Create an AppKernel and extends the Symfony\Bundle\FrameworkBundle\Kernel\MicroKernel class.', correct: false }
       - { value: 'Create an AppKernel and extends the Symfony\Component\HttpKernel\MicroKernel class.', correct: false }
     help: 'https://symfony.com/doc/current/configuration/micro_kernel_trait.html'
   -


### PR DESCRIPTION
The Symfony\Bundle\FrameworkBundle\Kernel\MicroKernel class doesn't exist instead use the Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait trait.