### PR TITLE
Update twig_syntax_up_to33_version.yaml to fix wrong answer

### DIFF
--- a/data/templating_with_twig/twig_syntax_up_to33_version.yaml
+++ b/data/templating_with_twig/twig_syntax_up_to33_version.yaml
@@ -123,9 +123,9 @@ questions:
     question: 'With twig, what is the correct way to display the value of a PHP constant?'
     answers:
       - { value: '{{ Namespace\\Classname::CONSTANT_NAME }}', correct: false }
-      - { value: "{{ constant('Namespace\\Classname::CONSTANT_NAME') }}", correct: false }
+      - { value: "{{ constant('Namespace\\Classname::CONSTANT_NAME') }}", correct: true }
       - { value: '{{ Namespace\Classname::CONSTANT_NAME }}', correct: false }
-      - { value: '{{ constant(''Namespace\\Classname::CONSTANT_NAME'') }}', correct: true }
+      - { value: '{{ constant(''Namespace\\Classname::CONSTANT_NAME'') }}', correct: false }
     help: 'https://twig.symfony.com/doc/functions/constant.html'
   -
     uuid: 1eebf878-8ba4-62de-8eca-99d84c92580c


### PR DESCRIPTION
The correct only syntax to display the value of PHP contant is using only the standard quote either simple quote or double quote.