### PR TITLE
Update string_interpolation.yaml to fix the question

### DIFF
--- a/data/templating_with_twig/string_interpolation.yaml
+++ b/data/templating_with_twig/string_interpolation.yaml
@@ -1,7 +1,7 @@
 questions:
   -
     uuid: 1eebf878-8ba8-6dca-82af-99d84c92580c
-    question: '{% set numA = 2 %} {%set numB = 3 %}  What will render {{ " #{numA + numB} " }} ?'
+    question: '{% set numA = 2 %} {% set numB = 3 %}  What will render {{ " #{numA + numB} " }} ?'
     answers:
       - { value: '2 + 3', correct: false }
       - { value: '5', correct: true }

--- a/data/templating_with_twig/string_interpolation.yaml
+++ b/data/templating_with_twig/string_interpolation.yaml
@@ -1,7 +1,7 @@
 questions:
   -
     uuid: 1eebf878-8ba8-6dca-82af-99d84c92580c
-    question: '{% set numA = 2 %} {%set numB = 3 %}  What will render {{  #{numA + numB}  }} ?'
+    question: '{% set numA = 2 %} {%set numB = 3 %}  What will render {{ " #{numA + numB} " }} ?'
     answers:
       - { value: '2 + 3', correct: false }
       - { value: '5', correct: true }


### PR DESCRIPTION
I got SyntaxError when I run the script. I follow the link to read the doc and it said "String interpolation (#{expression}) allows any valid expression to appear within a double-quoted string". Then I put the double quote and run the script again so it run correctly without error.